### PR TITLE
Stop tracking generated Fresnel plot asset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+assets/*.png

--- a/README.md
+++ b/README.md
@@ -1,1 +1,4 @@
-# slack-codex-tests
+# Fresnel Integral Sweep
+
+Run `python compute_integral.py` to tabulate $I(a)=\int_0^\infty \sin(a x^2)\,dx$ for several scales, comparing the closed form with SciPy's oscillatory quadrature and an adaptive Simpson cross-check.
+The script saves the comparison plot locally as `assets/fresnel_comparison.png`.

--- a/compute_integral.py
+++ b/compute_integral.py
@@ -1,27 +1,37 @@
-"""Compute the Fresnel integral ∫₀^∞ sin(x²) dx numerically.
-
-The integral can be mapped to the Euler gamma function by substituting
-``y = x²``:
-
-    ∫₀^∞ sin(x²) dx = ½ ∫₀^∞ y^{-1/2} sin(y) dy.
-
-For ``0 < s < 1`` the identity ``∫₀^∞ y^{s-1} sin(y) dy = Γ(s) sin(π s / 2)``
-holds, and setting ``s = 1/2`` yields the closed-form value ``√(π/8)``.  The
-script evaluates this expression numerically and also confirms it by directly
-numerically integrating ``sin(x²)`` over a large finite interval with an
-adaptive Simpson rule plus a vanishing tail estimate.
-"""
+"""Evaluate Fresnel-type integrals ∫₀^∞ sin(a x²) dx for several scale factors."""
 
 from __future__ import annotations
 
 import math
-from typing import Callable, Tuple
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, List, Sequence
+
+import importlib.util
+
+if importlib.util.find_spec("scipy") is None:
+    raise ModuleNotFoundError(
+        "SciPy is required for this script. Install it with `pip install scipy`."
+    )
+
+from scipy import integrate
+import matplotlib.pyplot as plt
 
 
-def analytic_value() -> float:
-    """Return √(π/8) via the gamma-function identity."""
+@dataclass
+class Result:
+    a: float
+    analytic: float
+    scipy_value: float
+    scipy_error: float
+    adaptive_value: float
+    tail_estimate: float
 
-    return 0.5 * math.gamma(0.5) * math.sin(math.pi / 4.0)
+
+def analytic_value(a: float) -> float:
+    """Closed form √(π/(8a)) for a > 0."""
+
+    return math.sqrt(math.pi / (8.0 * a))
 
 
 def simpson(f: Callable[[float], float], a: float, b: float) -> float:
@@ -55,16 +65,11 @@ def adaptive_simpson(
     )
 
 
-def numerical_check(cutoff: float = 120.0, tol: float = 1e-9) -> Tuple[float, float]:
-    """Integrate numerically on ``[0, cutoff]`` and estimate the tail."""
+def sinx2_tail(cutoff: float) -> float:
+    """Asymptotic tail ∫₍cutoff₎^∞ sin(x²) dx using 7-term expansion."""
 
-    f = lambda x: math.sin(x * x)
-    base = adaptive_simpson(f, 0.0, cutoff, tol)
-
-    # Tail estimate from Abramowitz & Stegun 7.3.26 with the first seven terms
-    # of the asymptotic expansion.
     r2 = cutoff * cutoff
-    tail = (
+    return (
         math.cos(r2) / (2.0 * cutoff)
         - math.sin(r2) / (4.0 * cutoff**2)
         - 3.0 * math.cos(r2) / (8.0 * cutoff**3)
@@ -73,21 +78,98 @@ def numerical_check(cutoff: float = 120.0, tol: float = 1e-9) -> Tuple[float, fl
         - 945.0 * math.sin(r2) / (64.0 * cutoff**6)
         - 10395.0 * math.cos(r2) / (128.0 * cutoff**7)
     )
+
+
+def adaptive_fresnel(a: float, cutoff: float = 120.0, tol: float = 1e-9) -> tuple[float, float]:
+    """Adaptive Simpson evaluation with asymptotic tail correction."""
+
+    integrand = lambda x: math.sin(a * x * x)
+    base = adaptive_simpson(integrand, 0.0, cutoff, tol)
+    scaled_cutoff = math.sqrt(a) * cutoff
+    tail = sinx2_tail(scaled_cutoff) / math.sqrt(a)
     return base + tail, abs(tail)
 
 
-def compute_integral() -> Tuple[float, float, float]:
-    closed_form = analytic_value()
-    numeric, tail_bound = numerical_check()
-    return closed_form, numeric, tail_bound
+def scipy_fresnel(a: float) -> tuple[float, float]:
+    """SciPy quad integration using oscillatory weighting."""
+
+    def base(x: float) -> float:
+        if x == 0.0:
+            return 0.0
+        return 0.5 / math.sqrt(x)
+
+    value, error = integrate.quad(
+        base,
+        0.0,
+        math.inf,
+        weight="sin",
+        wvar=a,
+        limit=500,
+    )
+    return value, error
+
+
+def evaluate(a_values: Sequence[float]) -> List[Result]:
+    results: List[Result] = []
+    for a in a_values:
+        analytic = analytic_value(a)
+        scipy_value, scipy_error = scipy_fresnel(a)
+        adaptive_value, tail_estimate = adaptive_fresnel(a)
+        results.append(
+            Result(
+                a=a,
+                analytic=analytic,
+                scipy_value=scipy_value,
+                scipy_error=scipy_error,
+                adaptive_value=adaptive_value,
+                tail_estimate=tail_estimate,
+            )
+        )
+    return results
+
+
+def render_plot(results: Sequence[Result], output_path: Path) -> None:
+    a_values = [r.a for r in results]
+    analytic = [r.analytic for r in results]
+    scipy_values = [r.scipy_value for r in results]
+    adaptive_values = [r.adaptive_value for r in results]
+
+    plt.figure(figsize=(6.0, 4.0))
+    plt.plot(a_values, analytic, marker="o", label="Analytic √(π/(8a))")
+    plt.plot(a_values, scipy_values, marker="s", label="SciPy quad")
+    plt.plot(a_values, adaptive_values, marker="^", label="Adaptive Simpson")
+    plt.xlabel("a")
+    plt.ylabel(r"$I(a) = \int_0^\infty \sin(a x^2)\,dx$")
+    plt.title("Fresnel Integral Comparison")
+    plt.grid(True, linestyle="--", alpha=0.4)
+    plt.legend()
+    plt.tight_layout()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    plt.savefig(output_path, dpi=200)
+    plt.close()
+
+
+def print_results(results: Sequence[Result]) -> None:
+    header = f"{'a':>6}  {'Analytic':>12}  {'SciPy':>12}  {'|Δ| (SciPy)':>12}  {'Adaptive':>12}  {'|Δ| (Adaptive)':>15}"
+    print(header)
+    print("-" * len(header))
+    for r in results:
+        scipy_diff = abs(r.analytic - r.scipy_value)
+        adaptive_diff = abs(r.analytic - r.adaptive_value)
+        print(
+            f"{r.a:6.2f}  {r.analytic:12.9f}  {r.scipy_value:12.9f}  {scipy_diff:12.3e}  "
+            f"{r.adaptive_value:12.9f}  {adaptive_diff:15.3e}"
+        )
 
 
 def main() -> None:
-    closed_form, numeric, tail_bound = compute_integral()
-    print(f"Closed-form evaluation √(π/8)     = {closed_form:.12f}")
-    print(f"Adaptive Simpson + tail estimate = {numeric:.12f}")
-    print(f"Tail magnitude upper bound        ≈ {tail_bound:.1e}")
-    print(f"Absolute difference                = {abs(closed_form - numeric):.3e}")
+    a_values = [0.1, 0.25, 0.5, 1.0, 2.0, 5.0]
+    results = evaluate(a_values)
+    print_results(results)
+
+    output_path = Path(__file__).resolve().parent / "assets" / "fresnel_comparison.png"
+    render_plot(results, output_path)
+    print(f"\nSaved comparison plot to {output_path.relative_to(Path.cwd())}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- stop tracking the generated Fresnel comparison PNG and ignore future regenerated images
- tighten the README description while noting the plot is saved locally by the script

## Testing
- python compute_integral.py

------
https://chatgpt.com/codex/tasks/task_e_68e47b546bc4832fbfac37a9b401dbc5